### PR TITLE
Replace hijacked URL with current one

### DIFF
--- a/Lib/venv/scripts/posix/activate.fish
+++ b/Lib/venv/scripts/posix/activate.fish
@@ -1,5 +1,5 @@
 # This file must be used with "source <venv>/bin/activate.fish" *from fish*
-# (http://fishshell.org); you cannot run it directly.
+# (https://fishshell.com/); you cannot run it directly.
 
 function deactivate  -d "Exit virtual environment and return to normal shell environment"
     # reset old environment variables


### PR DESCRIPTION
I tried to load the URL this evening and got hijacked to some Chinese or Japanese pharmacy site. A quick Google search found the new URL, and this replaces the outdated one. Since the URL is hijacked and this is only a comment (i.e. no code changes), I propose that this be backported to all active branches, including security-fix-only branches.

There isn't an issue for this, but I can create one if deemed necessary. Likewise for a news entry. I feel this is trivial enough to not need either, but I'm willing to be contradicted.